### PR TITLE
scope PagePostRender#localizeUrls to href declarations

### DIFF
--- a/lib/initializers/PagePostRender.js
+++ b/lib/initializers/PagePostRender.js
@@ -45,8 +45,8 @@ module.exports = Initializer.extend({
         var localizedPage = pages.get(localizedUrl);
 
         if (localizedPage) {
-          var url = '"' + page.attributes.url + '"';
-          var newUrl = '"' + localizedUrl + '"';
+          var url = 'href="' + page.attributes.url + '"';
+          var newUrl = 'href="' + localizedUrl + '"';
           var expr = new RegExp(url, 'g');
           rendered = rendered.replace(expr, localizedUrl);
         }


### PR DESCRIPTION
As currently written this helper replaces any and all strings that
could be a link, instead of actual links.  I am not sure what the
intended behavior is as there is no test for this.
