### PR TITLE
normalize url, remove query params

### DIFF
--- a/lib/middleware/dirtyRenderCheck.js
+++ b/lib/middleware/dirtyRenderCheck.js
@@ -1,21 +1,8 @@
 var asimov = require('asimov');
 var _ = require('lodash');
 
-function dirtyRenderCheckMiddleware (req, res, next) {
-
-  var url = req.url;
-  if (url !== '/' && url[url.length - 1] === '/') {
-    url = url.substr(0, url.length - 1);
-  }
-
-  asimov.requestData({
-    'url': url
-  }, function (data) {
-    next();
-  });
-}
-
 function normalizeUrl (url) {
+  url = url.split('?')[0];
   if (url.length > 1 && url[url.length - 1] === '/') {
     url = url.substr(0, url.length - 1);
   }
@@ -35,6 +22,15 @@ function findModel (url) {
 }
 
 var find = _.memoize(findModel);
+
+function dirtyRenderCheckMiddleware (req, res, next) {
+
+  asimov.requestData({
+    'url': normalizeUrl(req.url)
+  }, function (data) {
+    next();
+  });
+}
 
 function dirtyRenderCheckResponder (data, next) {
   


### PR DESCRIPTION
fixes issue where in DEV mode, urls like ```/de/?foo=bar``` never renders the right file